### PR TITLE
Update the Harfbuzz dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends:
   libgmp-dev,
   libgraphite2-dev,
   libgs-dev,
-  libharfbuzz-dev (>= 0.9.18-3),
+  libharfbuzz-dev (>= 2.4),
   libicu-dev,
   libmpfr-dev,
   libncurses5-dev | libncurses-dev,


### PR DESCRIPTION
luaharfbuzz in TeX Live 2020 needs HB_BUFFER_FLAG_DO_NOT_INSERT_DOTTED_CIRCLE which was added in 2.4.