### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+texlive-bin (2020.20200327.54578-8) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since stretch:
+    + Build-Depends: Drop versioned constraint on autoconf, libtool and m4.
+    + texlive-binaries: Drop versioned constraint on dpkg and tex-common in
+      Depends.
+    + texlive-binaries: Drop versioned constraint on m-tx, musixtex, pmx, tex4ht
+      and texlive-base in Replaces.
+    + texlive-binaries: Drop versioned constraint on context, m-tx, musixtex,
+      pmx, tex-common and tex4ht in Breaks.
+    + libkpathsea6: Drop versioned constraint on texlive-base in Breaks.
+    + libptexenc1: Drop versioned constraint on texlive-base in Breaks.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 22 Apr 2021 16:29:38 -0000
+
 texlive-bin (2020.20200327.54578-7) unstable; urgency=medium
 
   * Backport several security fixes for shell escape exploits in

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Debian TeX Task Force <debian-tex-maint@lists.debian.org>
 Uploaders: Norbert Preining <norbert@preining.info>,
 	Hilmar Preusse <hille42@web.de>
 Build-Depends:
-  autoconf (>= 2.69),
+  autoconf,
   automake (>= 1:1.13.1),
   bison,
   debhelper-compat (= 12),
@@ -23,11 +23,11 @@ Build-Depends:
   libpixman-1-dev (>= 0.32.4),
   libpng-dev,
   libteckit-dev,
-  libtool (>= 2.4.2),
+  libtool,
   libxaw7-dev,
   libxi-dev,
   libzzip-dev (>= 0.12),
-  m4 (>= 1.4.16),
+  m4,
   texlive-binaries <cross>,
   zlib1g-dev | libz-dev
 Rules-Requires-Root: no
@@ -51,11 +51,11 @@ Depends: libptexenc1 (>= ${source:Version}),
   libtexluajit2 (<< ${source:Version}.1~) [amd64 armel armhf hurd-i386 i386 kfreebsd-amd64 kfreebsd-i386 powerpc],
   t1utils,
   ${shlibs:Depends}, ${misc:Depends},
-  tex-common (>= 6), perl, dpkg (>= 1.15.4) | install-info
+  tex-common, perl, dpkg | install-info
 Recommends: texlive-base, dvisvgm
-Replaces: texlive-metapost (<< 2010), texlive-base (<< 2010), ptex-bin, mendexk, jmpost, luatex (<< 2014), musixtex (<< 1:1.20.ctan20151216-3), pmx (<< 2.7.0.ctan20150301-3), m-tx (<< 0.61.ctan20151217-2), gregorio (<= 2.3-1), tex4ht (<< 20160814), texlive-lang-japanese (<< 2017), texlive-extra-utils (<< 2020.20200329), texlive-luatex (<< 2020.20200329)
+Replaces: texlive-metapost (<< 2010), ptex-bin, mendexk, jmpost, luatex (<< 2014), gregorio (<= 2.3-1), texlive-lang-japanese (<< 2017), texlive-extra-utils (<< 2020.20200329), texlive-luatex (<< 2020.20200329)
 Conflicts: mendexk, makejvf, jmpost
-Breaks: texlive-base (<< 2020), jtex-bin, multex-bin, luatex (<< 2014), tex-common (<< 6), musixtex (<< 1:1.20.ctan20151216-3), pmx (<< 2.7.0.ctan20150301-3), m-tx (<< 0.61.ctan20151217-2), gregorio (<= 2.3-1), context (<< 2016), tex4ht (<< 20160814), texlive-htmlxml (<< 2016.20160829), texlive-extra-utils (<< 2020.20200329), texlive-luatex (<< 2020.20200329)
+Breaks: texlive-base (<< 2020), jtex-bin, multex-bin, luatex (<< 2014), gregorio (<= 2.3-1), texlive-htmlxml (<< 2016.20160829), texlive-extra-utils (<< 2020.20200329), texlive-luatex (<< 2020.20200329)
 Provides: texlive-base-bin, makejvf, mendexk, jmpost, luatex
 Description: Binaries for TeX Live
  This package contains all the binaries of TeX Live packages.
@@ -70,7 +70,7 @@ Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends}, ${shlibs:Depends}
-Breaks: texlive-binaries (<< 2014), texlive-base (<< 2014)
+Breaks: texlive-binaries (<< 2014)
 Description: TeX Live: path search library for TeX (runtime part)
  This package contains the runtime part of the Kpathsea[rch] library,
  which implements generic path searching, configuration, and
@@ -92,7 +92,7 @@ Architecture: any
 Multi-Arch: same
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Pre-Depends: ${misc:Pre-Depends}
-Breaks: texlive-binaries (<< 2014), texlive-base (<< 2014)
+Breaks: texlive-binaries (<< 2014)
 Description: TeX Live: pTeX encoding library
  library for encoding support in pTeX, a Japanese TeX engine.
 


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/texlive-bin/4c321a02-238d-40f5-badd-113dc5ce05f6.



These changes affect the binary packages; see the
[debdiff](https://janitor.debian.net/api/run/\
4c321a02-238d-40f5-badd-113dc5ce05f6/debdiff?filter_boring=1)


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/4c321a02-238d-40f5-badd-113dc5ce05f6/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/4c321a02-238d-40f5-badd-113dc5ce05f6/diffoscope)).
