### PR TITLE
Various build fixes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -7,6 +7,7 @@ texlive-bin (2025.20250727.75242+ds-5) UNRELEASED; urgency=medium
     copy on any i386 architecture, not only on Linux, as the problem applies
     regardless of the OS.
   * Enable the luajit support also on hurd-amd64.
+  * Add a workaround for missing automake dependencies in single job builds.
 
  -- Debian TeX Task Force <debian-tex-maint@lists.debian.org>  Sun, 17 Aug 2025 09:38:50 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,7 @@ texlive-bin (2025.20250727.75242+ds-5) UNRELEASED; urgency=medium
   * Use DEB_HOST_ARCH rather than DEB_HOST_ARCH_CPU to use the embedded zziplib
     copy on any i386 architecture, not only on Linux, as the problem applies
     regardless of the OS.
+  * Enable the luajit support also on hurd-amd64.
 
  -- Debian TeX Task Force <debian-tex-maint@lists.debian.org>  Sun, 17 Aug 2025 09:38:50 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,9 @@ texlive-bin (2025.20250727.75242+ds-5) UNRELEASED; urgency=medium
   [ Pino Toscano ]
   * Import patch 0001-consider-Hurd-as-a-POSIX-system.patch from src:luajit as
     luajit-hurd.diff to support Hurd in the embedded luajit copy.
+  * Use DEB_HOST_ARCH rather than DEB_HOST_ARCH_CPU to use the embedded zziplib
+    copy on any i386 architecture, not only on Linux, as the problem applies
+    regardless of the OS.
 
  -- Debian TeX Task Force <debian-tex-maint@lists.debian.org>  Sun, 17 Aug 2025 09:38:50 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+texlive-bin (2025.20250727.75242+ds-5) UNRELEASED; urgency=medium
+
+
+ -- Debian TeX Task Force <debian-tex-maint@lists.debian.org>  Sun, 17 Aug 2025 09:38:50 +0200
+
 texlive-bin (2025.20250727.75242+ds-4) unstable; urgency=medium
 
   * Upload to unstable.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,8 @@
 texlive-bin (2025.20250727.75242+ds-5) UNRELEASED; urgency=medium
 
+  [ Pino Toscano ]
+  * Import patch 0001-consider-Hurd-as-a-POSIX-system.patch from src:luajit as
+    luajit-hurd.diff to support Hurd in the embedded luajit copy.
 
  -- Debian TeX Task Force <debian-tex-maint@lists.debian.org>  Sun, 17 Aug 2025 09:38:50 +0200
 

--- a/debian/control
+++ b/debian/control
@@ -53,7 +53,7 @@ Depends: libptexenc1 (>= ${source:Version}),
   t1utils, tex-common, perl:any,
   ${shlibs:Depends}, ${misc:Depends}
 Recommends: texlive-base, dvisvgm
-Suggests: texlive-binaries-sse2 [amd64 armel armhf arm64 hurd-i386 i386 powerpc], hintview
+Suggests: texlive-binaries-sse2 [amd64 armel armhf arm64 hurd-amd64 hurd-i386 i386 powerpc], hintview
 Replaces: ptex-bin, mendexk, jmpost, luatex (<< 2014), gregorio (<= 2.3-1),
     texlive-extra-utils (<< 2020.20200329), texlive-luatex (<< 2020.20200329)
 Conflicts: mendexk, makejvf, jmpost
@@ -69,7 +69,7 @@ Description: Binaries for TeX Live
  texlive-latex-recommended or context
 
 Package: texlive-binaries-sse2
-Architecture: amd64 armel armhf arm64 hurd-i386 i386 powerpc
+Architecture: amd64 armel armhf arm64 hurd-amd64 hurd-i386 i386 powerpc
 Multi-Arch: foreign
 Depends: libptexenc1 (>= ${source:Version}),
   libptexenc1 (<< ${source:Version}.1~),
@@ -79,8 +79,8 @@ Depends: libptexenc1 (>= ${source:Version}),
   libsynctex2 (<< ${source:Version}.1~),
   libtexlua53-5 (>= ${source:Version}),
   libtexlua53-5 (<< ${source:Version}.1~),
-  libtexluajit2 (>= ${source:Version}) [amd64 armel armhf arm64 hurd-i386 i386 powerpc],
-  libtexluajit2 (<< ${source:Version}.1~) [amd64 armel armhf arm64 hurd-i386 i386 powerpc],
+  libtexluajit2 (>= ${source:Version}) [amd64 armel armhf arm64 hurd-amd64 hurd-i386 i386 powerpc],
+  libtexluajit2 (<< ${source:Version}.1~) [amd64 armel armhf arm64 hurd-amd64 hurd-i386 i386 powerpc],
   sse2-support [i386],
   t1utils, tex-common, perl:any,
   ${shlibs:Depends}, ${misc:Depends}, texlive-binaries
@@ -192,7 +192,7 @@ Description: TeX Live: Lua 5.3, modified for use with LuaTeX (development part)
 
 Package: libtexluajit2
 Section: libs
-Architecture: amd64 armel armhf arm64 hurd-i386 i386 powerpc
+Architecture: amd64 armel armhf arm64 hurd-amd64 hurd-i386 i386 powerpc
 Multi-Arch: same
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Pre-Depends: ${misc:Pre-Depends}
@@ -201,7 +201,7 @@ Description: TeX Live: LuaJIT, modified for use with LuaJITTeX
 
 Package: libtexluajit-dev
 Section: libdevel
-Architecture: amd64 armel armhf arm64 hurd-i386 i386 powerpc
+Architecture: amd64 armel armhf arm64 hurd-amd64 hurd-i386 i386 powerpc
 Multi-Arch: same
 Depends: ${misc:Depends}, libtexluajit2 (= ${binary:Version})
 Description: TeX Live: LuaJIT, modified for use with LuaJITTeX (development part)

--- a/debian/patches/luajit-hurd.diff
+++ b/debian/patches/luajit-hurd.diff
@@ -1,0 +1,32 @@
+From: Enrico Tassi <gareuselesinge@debian.org>
+Date: Fri, 14 Aug 2015 16:11:50 +0200
+Subject: consider Hurd as a POSIX system
+
+---
+ src/Makefile  | 3 +++
+ src/lj_arch.h | 2 ++
+ 2 files changed, 5 insertions(+)
+
+--- a/libs/luajit/LuaJIT-src/src/Makefile
++++ b/libs/luajit/LuaJIT-src/src/Makefile
+@@ -354,6 +354,9 @@ else
+   ifeq (GNU/kFreeBSD,$(TARGET_SYS))
+     TARGET_XLIBS+= -ldl
+   endif
++  ifeq (GNU,$(TARGET_SYS))
++    TARGET_XLIBS+= -ldl
++  endif
+ endif
+ endif
+ endif
+--- a/libs/luajit/LuaJIT-src/src/lj_arch.h
++++ b/libs/luajit/LuaJIT-src/src/lj_arch.h
+@@ -96,6 +96,8 @@
+ #elif defined(__QNX__)
+ #define LJ_TARGET_QNX		1
+ #define LUAJIT_OS	LUAJIT_OS_POSIX
++#elif defined(__GNU__)
++#define LUAJIT_OS	LUAJIT_OS_POSIX
+ #else
+ #define LUAJIT_OS	LUAJIT_OS_OTHER
+ #endif

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -47,3 +47,4 @@ gcc-15/6bf2b2d8ad6bfc810038ba8d426cc603f88ae99a.patch
 texlive_svn_r75793.diff
 texlive_svn_r74888.diff
 zziplib.diff
+luajit-hurd.diff

--- a/debian/rules
+++ b/debian/rules
@@ -174,6 +174,25 @@ override_dh_auto_configure-arch:
 	--enable-ttf2pk2			\
 	--enable-ipc				
 
+	# HACK: manually create the detex-src subdirectory inside the build
+	# directory to ensure it exists; the situation is the following:
+	# - texk/detex/Makefile.am has a rule to generate detex-src/detex.h
+	#   from detex-src/detex.l using lex (wrapped in build-aux/ylwrap)
+	# - ylwrap does not create any missing subdirectory for the output file
+	# - automake (currently 1.17) generate a rule to create the needed
+	#   subdirectory, however it is only added as dependency for the
+	#   detex-src/detex.o object file (build from detex-src/detex.c, which
+	#   includes the generated detex-src/detex.h); this rule is also
+	#   written in the Makefile after the rule to invoke ylwrap
+	# - GNU make starting from 4.4 remakes rules in the same order they
+	#   were processed, rather the opposite as in previous versions
+	# When building with a single build job, the rule to generate
+	# detex-src/detex.h is processed before the rule to create the output
+	# subdirectory; thus in a builddir!=srcdir build ylwrap fails as:
+	# ../../../texk/detex/../../build-aux/ylwrap: line 204: ../detex-src/detex.c: No such file or directory
+	# While this feels like a bug in automake, work around it for now.
+	mkdir -p $(CURDIR)/Work/texk/detex/detex-src/
+
 override_dh_auto_configure-indep:
 	# Nothing to do here
 

--- a/debian/rules
+++ b/debian/rules
@@ -17,7 +17,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 # all cases. We have now two ways to test for where to build.
 # One by disabling on the other platforms, one by whitelisting
 # and building only on some platforms.
-LUAJIT_GOOD_ARCHS := amd64 armel armhf arm64 hurd-i386 i386 powerpc
+LUAJIT_GOOD_ARCHS := amd64 armel armhf arm64 hurd-amd64 hurd-i386 i386 powerpc
 
 # In case one wants to build with old automake (<< 1.13.1), the following
 # variable has to be set. By default the debian/control requires high

--- a/debian/rules
+++ b/debian/rules
@@ -57,7 +57,7 @@ endif
 
 ZZIPLIB=--with-system-zziplib
 
-ifeq ($(DEB_HOST_ARCH), i386))
+ifeq ($(DEB_HOST_ARCH_CPU), i386)
   # Not use system zziplib on i386 arches.
   ZZIPLIB=--without-system-zziplib
 endif


### PR DESCRIPTION
- support Hurd in embedded luajit
- use embedded zziplib on any i386 OS (Hurd included)
- workaround possible automake issue in builddir!=srcdir single-job builds (see explanation in `debian/rules`)